### PR TITLE
DBT-749: Showcasing how to use pre-hook for setting hive properties at individual models

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is recommended to use `venv` to create a Python virtual environment for the d
 ## Requirements
 
 - Python >= 3.8
-- dbt-core >= 1.1.0
+- dbt-core >= 1.4.0
 - git
 
 ## Install
@@ -20,11 +20,12 @@ Start by cloning this repo
 
 `git clone https://github.com/cloudera/dbt-hive-example.git`
 
-Next install the requirements
+Next install the requirements like dbt-core & dbt-hive
 
-`pip install dbt-core`
-
-`pip install dbt-hive`
+```
+cd dbt_hive_demo
+pip install -r requirements.txt
+```
 
 ## Configure
 

--- a/dbt_hive_demo/models/marts/covid/covid_cases.sql
+++ b/dbt_hive_demo/models/marts/covid/covid_cases.sql
@@ -18,7 +18,8 @@
 
 {{
     config(
-        materialized='incremental'
+        materialized='incremental',
+        pre_hook=["set hive.exec.dynamic.partition=true;"],
     )
 }}
 

--- a/dbt_hive_demo/requirements.txt
+++ b/dbt_hive_demo/requirements.txt
@@ -1,0 +1,3 @@
+dbt-core~=1.4.0
+dbt-hive~=1.4.0
+


### PR DESCRIPTION
Customers can use the dbt [pre-hooks](https://docs.getdbt.com/reference/resource-configs/pre-hook-post-hook) to set the hive properties for individual models or queries, the ONLY condition that the hive should support those properties at the query level. 

With the pre-hook show-cases that set command runs in the logs https://gist.github.com/niteshy/be44b6eca1ea460da2ae210a5455edba#file-dbt-hive-testing-set-parameters-L106 

Whereas without the pre-hooks https://gist.github.com/niteshy/be44b6eca1ea460da2ae210a5455edba#file-dbt-hive-testing-set-parameters-L325-L333 